### PR TITLE
Add NVFP4 GPTQ support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## MoE-Quant
 ---
 
-This repository provides code for [GPTQ](https://arxiv.org/abs/2210.17323) quantization of [DeepSeekV3](https://huggingface.co/deepseek-ai/DeepSeek-V3)/[DeepSeekR1](https://huggingface.co/deepseek-ai/DeepSeek-R1) model family.
+This repository provides code for [GPTQ](https://arxiv.org/abs/2210.17323) quantization of [DeepSeekV3](https://huggingface.co/deepseek-ai/DeepSeek-V3)/[DeepSeekR1](https://huggingface.co/deepseek-ai/DeepSeek-R1) and OLMoE model families.
 
 ### News 🔥
 
@@ -20,7 +20,7 @@ Since one has to quantize a lot (really a lot - ~45k) of linear layers, a faster
 
 Currently we support conversion of `GPTQ`-quantized model into the [compressed_tensors](https://github.com/neuralmagic/compressed-tensors) format supported in HuggingFace transformers and vLLM. 
 
-At the moment only 4-bit symmetric quantization with different quantization group sizes is supported.
+At the moment only 4-bit symmetric quantization with different quantization group sizes is supported, including both `int4` and `nvfp4` formats.
 We plan to implement other bit widths and quantization formats (`AWQ`, `AutoGPQ`) in the future. 
 
 

--- a/pack_quantized_model.py
+++ b/pack_quantized_model.py
@@ -79,6 +79,7 @@ def prepare_quantization_config(args: argparse.Namespace) -> dict[str, Any]:
     ignored_modules = ["lm_head"]
     if args.quantize_only_experts:
         ignored_modules += ["re:.*self_attn.*", "re:.*shared_experts.*", "re:.*mlp\.(gate|up|gate_up|down)_proj.*"]
+    weight_type = "int" if args.quant_format == "int4" else args.quant_format
     return {
         "config_groups": {
             "group_0": {
@@ -97,7 +98,7 @@ def prepare_quantization_config(args: argparse.Namespace) -> dict[str, Any]:
                     "observer_kwargs": {},
                     "strategy": "group",
                     "symmetric": True,
-                    "type": "int"
+                    "type": weight_type
                 }
             }
         },
@@ -134,6 +135,7 @@ def main():
     args.bits = metadata["bits"]
     args.group_size = metadata["group_size"]
     args.quantize_only_experts = metadata["quantize_only_experts"]
+    args.quant_format = metadata.get("quant_format", "int4")
     # Currently we do not support asymmetric quantization
     args.sym = True
 

--- a/quant.py
+++ b/quant.py
@@ -61,6 +61,13 @@ def parse_args():
     parser.add_argument("--quantization_scale", type=str, default="absmax", choices=["absmax", "mse"])
     parser.add_argument("--quantization_order", type=str, default="default", choices=["default", "activation"])
     parser.add_argument(
+        "--quant_format",
+        type=str,
+        default="int4",
+        choices=["int4", "nvfp4"],
+        help="Weight quantization format",
+    )
+    parser.add_argument(
         "--quantize_only_experts",
         default=False,
         action="store_true",
@@ -115,10 +122,10 @@ def main():
         assert wandb_enabled, "wandb not installed. try `pip install wandb`"
         wandb.init(config=args)
 
-    # Load DeepSeek model
+    # Load model
     config = AutoConfig.from_pretrained(args.model_name_or_path, trust_remote_code=True)
-    # Sanity check
-    assert config.architectures == ["DeepseekV3ForCausalLM"], "Only DeepseekV3 is supported!"
+    if config.architectures[0] not in ["DeepseekV3ForCausalLM", "OLMoEForCausalLM"]:
+        raise ValueError("Only DeepseekV3 and OLMoE models are supported!")
     if hasattr(config, "quantization_config"):
         delattr(config, "quantization_config")
     config.ep_size = world_size
@@ -270,8 +277,9 @@ def main():
                     args.quantization_order,
                     args.quantization_scale,
                     is_distributed=re.search(ROUTED_EXPERTS_REGEX, layer_name) is None,
-                    tied_gptq_handle=tied_gptq_handle
-                )    
+                    tied_gptq_handle=tied_gptq_handle,
+                    quant_format=args.quant_format,
+                )
 
                 if tied_gptq_handle is None:
                     hooks[layer_name] = layer.register_forward_hook(update_handle_hook(layer_name))
@@ -296,7 +304,9 @@ def main():
                 dist_utils.print_on_main(f"Quantizing layer {handle_name}")
                 qweight, scale, zero = handle.quantize(args.bits)
                 # Construct dequantized weight
-                dequantized_weight = quant_utils.dequantize_linear_weight(qweight, scale, zero)
+                dequantized_weight = quant_utils.dequantize_linear_weight(
+                    qweight, scale, zero, quant_format=args.quant_format
+                )
                 assert (
                     torch.isfinite(dequantized_weight).all().item()
                 ), f"[rank{rank}] {handle_name} weight is broken after quantization."
@@ -321,9 +331,9 @@ def main():
                 if args.save_dir and dist_utils.is_main():
                     os.makedirs(os.path.join(args.save_dir, handle_name), exist_ok=True)
                     torch.save(
-                        {"qweight": qweight, "scale": scale, "zero": zero},
-                        os.path.join(args.save_dir, handle_name, f"quantized_weight.pt"),
-                    )
+            {"qweight": qweight, "scale": scale, "zero": zero},
+            os.path.join(args.save_dir, handle_name, f"quantized_weight.pt"),
+        )
                 # Replace original weight by quantized one
                 handle.layer.weight.data = dequantized_weight
                 # Destroy handle
@@ -429,7 +439,8 @@ def main():
             {
                 "bits": args.bits,
                 "group_size": args.group_size,
-                "quantize_only_experts": args.quantize_only_experts
+                "quantize_only_experts": args.quantize_only_experts,
+                "quant_format": args.quant_format,
             },
             os.path.join(args.save_dir, "metadata.pt")
         )

--- a/src/gptq.py
+++ b/src/gptq.py
@@ -31,7 +31,8 @@ class GPTQ:
         quantization_order: str = "default",
         quantization_scale: str = "absmax",
         is_distributed: bool = False,
-        tied_gptq_handle: Optional["GPTQ"] = None
+        tied_gptq_handle: Optional["GPTQ"] = None,
+        quant_format: str = "int4",
     ):
         self._validate_layer(layer)
         self.layer = layer
@@ -45,6 +46,7 @@ class GPTQ:
         self.block_size = block_size or self.d_col
         self.quantization_order = QuantizationOrder(quantization_order)
         self.quantization_scale = quantization_scale
+        self.quant_format = quant_format
         # backup layer properties
         self.W_device = self.W.device
         self.W_dtype = self.W.dtype
@@ -175,6 +177,7 @@ class GPTQ:
                 symmetric=self.sym,
                 dtype=dtype,
                 quantization_scale=self.quantization_scale,
+                quant_format=self.quant_format,
             )
             # Get permutation
             if self.quantization_order == QuantizationOrder.ACTIVATION:
@@ -189,13 +192,14 @@ class GPTQ:
             hessian_inv = self._get_hessian_inverse()
             # Quantize
             qweight = gptq_loop.gptq_loop(
-                weight=self.W.transpose(-2, -1)[perm],  
+                weight=self.W.transpose(-2, -1)[perm],
                 hessian_inv=hessian_inv,
-                scale=scale.transpose(-2, -1)[perm], 
-                qzero=zero.transpose(-2, -1)[perm],  
-                maxq=maxq, 
+                scale=scale.transpose(-2, -1)[perm],
+                qzero=zero.transpose(-2, -1)[perm],
+                maxq=maxq,
                 dtype=dtype,
                 gptq_block_size=block_size,
+                quant_format=self.quant_format,
             )[perm_inv].transpose(-2, -1).contiguous().to(torch.uint8)
             # Remove scale and zero replication  
             scale = scale[:, ::group_size].to(dtype)

--- a/src/gptq_loop.py
+++ b/src/gptq_loop.py
@@ -2,7 +2,7 @@ import torch
 import triton
 from triton import language as tl
 
-from src.quant_utils import tl_quantize, tl_dequantize
+from src.quant_utils import tl_quantize, tl_dequantize, nvfp4_quantize
 
 torch.backends.cuda.matmul.allow_tf32 = False
 torch.backends.cudnn.allow_tf32 = False
@@ -65,6 +65,18 @@ def quantize_error_triton(
     )
 
 
+def quantize_error_nvfp4(
+    x: torch.Tensor,
+    qx: torch.Tensor,
+    error: torch.Tensor,
+    scale: torch.Tensor,
+) -> None:
+    q, y = nvfp4_quantize(x, scale)
+    qx.copy_(q)
+    error.copy_(y - x)
+    x.copy_(y)
+
+
 @triton.jit
 def addvv_triton_kernel(
     vec_a_ptr,
@@ -116,6 +128,7 @@ def gptq_loop_graph(
     dtype: torch.dtype = None,
     gptq_block_size: int = 128,
     direct: bool = True,
+    quant_format: str = "int4",
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     CUDA Graph wrapper for GPTQ loops
@@ -169,10 +182,10 @@ def gptq_loop_graph(
         s.wait_stream(torch.cuda.current_stream())
         with torch.cuda.stream(s):
             for _ in range(n_warmups):
-                gptq_loop_graph(**graph_tensors, dtype=dtype, gptq_block_size=gptq_block_size, direct=True)
+                gptq_loop_graph(**graph_tensors, dtype=dtype, gptq_block_size=gptq_block_size, direct=True, quant_format=quant_format)
         torch.cuda.current_stream().wait_stream(s)
         with torch.cuda.graph(graph):
-            gptq_loop_graph(**graph_tensors, dtype=dtype, gptq_block_size=gptq_block_size, direct=True)
+            gptq_loop_graph(**graph_tensors, dtype=dtype, gptq_block_size=gptq_block_size, direct=True, quant_format=quant_format)
         gptq_loop_graph.graph_info[graph_key] = {"graph": graph, "tensors": graph_tensors}
 
     graph, graph_tensors = (
@@ -198,6 +211,7 @@ def gptq_loop(
     maxq: torch.Tensor,
     dtype: torch.dtype,
     gptq_block_size: int = 128,
+    quant_format: str = "int4",
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Quantize weight tensor with GPTQ algorithm
@@ -212,6 +226,18 @@ def gptq_loop(
     if gptq_block_size <= 0:
         gptq_block_size = weight.size(-2)
 
+    if quant_format == "nvfp4":
+        n_columns, n_rows = weight.shape
+        qweight = torch.empty_like(weight, dtype=torch.uint8)
+        error_block = torch.empty(gptq_block_size, n_rows, dtype=weight.dtype, device=weight.device)
+        for i1 in range(0, n_columns, gptq_block_size):
+            i2 = min(i1 + gptq_block_size, n_columns)
+            for j in range(i1, i2):
+                quantize_error_nvfp4(weight[j], qweight[j], error_block[j - i1], scale[j])
+                addvv_triton(hessian_inv[j, j + 1 : i2], error_block[j - i1], weight[j + 1 : i2])
+            weight[i2:].addmm_(hessian_inv[i1:i2, i2:].t(), error_block[: i2 - i1], beta=1, alpha=1)
+        return qweight
+
     qweight, _ = gptq_loop_graph(
         weight=weight,
         hessian_inv=hessian_inv,
@@ -221,5 +247,6 @@ def gptq_loop(
         dtype=dtype,
         gptq_block_size=gptq_block_size,
         direct=False,
+        quant_format=quant_format,
     )
-    return qweight # (C, R)
+    return qweight

--- a/src/quant_utils.py
+++ b/src/quant_utils.py
@@ -16,6 +16,34 @@ torch.set_float32_matmul_precision("highest")
 FP8_GROUP_SIZE = 128
 FP8_DTYPES = (torch.float8_e4m3fn, torch.float8_e4m3fnuz, torch.float8_e5m2, torch.float8_e5m2fnuz)
 
+# NVidia FP4 lookup table
+def _nvfp4_table(device: torch.device, dtype: torch.dtype) -> torch.Tensor:
+    q = torch.arange(16, device=device, dtype=torch.int16)
+    sign = 1 - 2 * ((q >> 3) & 1).float()
+    exp = ((q >> 1) & 0x3).float() - 1
+    mant = (q & 0x1).float()
+    table = sign * (1.0 + 0.5 * mant) * torch.pow(2.0, exp)
+    table[(q & 0x7) == 0] = 0.0
+    return table.to(dtype=dtype)
+
+
+def nvfp4_quantize(x: torch.Tensor, scale: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    table = _nvfp4_table(x.device, x.dtype)
+    x_scaled = x / scale
+    diff = (x_scaled.unsqueeze(-1) - table).abs()
+    q = diff.argmin(dim=-1).to(torch.uint8)
+    y = scale * table[q.long()]
+    return q, y
+
+
+def find_nvfp4_scale(x: torch.Tensor, dtype: torch.dtype = None) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    table = _nvfp4_table(x.device, x.dtype)
+    max_val = table.abs().max().item()
+    scale = round_fp(x.abs().amax(dim=-1) / max_val + 1e-12, dtype)
+    zero = torch.zeros_like(scale)
+    maxq = torch.tensor(15, dtype=x.dtype, device=x.device)
+    return scale, zero, maxq
+
 
 class QuantizationScale(Enum):
     ABSMAX = "absmax"
@@ -203,6 +231,7 @@ def get_quantization_grid(
     quant_max_shrink: float = 0.2,
     quant_n_grid: int = 100,
     quant_norm: float = 2.4,
+    quant_format: str = "int4",
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Get the quantization grid for the weight matrix
@@ -212,6 +241,13 @@ def get_quantization_grid(
     maxq: ()
     """
     weight = weight.unflatten(dim=-1, sizes=(-1, group_size))  # (..., G, gs)
+
+    if quant_format == "nvfp4":
+        scale, qzero, maxq = find_nvfp4_scale(weight, dtype)
+        scale = scale.repeat_interleave(group_size, dim=-1)
+        qzero = qzero.repeat_interleave(group_size, dim=-1)
+        weight = weight.flatten(start_dim=-2)
+        return scale, qzero, maxq
 
     scale, qzero, maxq = find_quantization_meta(
         x=weight,
@@ -245,11 +281,17 @@ def dequantize_linear_weight(
     scale: torch.Tensor,
     zero: torch.Tensor,
     perm: Optional[torch.Tensor] = None,
+    quant_format: str = "int4",
 ):
     scale = scale.view(qweight.shape[0], -1, 1)
     zero = zero.view(qweight.shape[0], -1, 1)
     num_groups = scale.shape[1]
-    weight = dequantize(qweight.view(qweight.shape[0], num_groups, -1), scale, zero).view_as(qweight)
+    if quant_format == "nvfp4":
+        table = _nvfp4_table(qweight.device, scale.dtype)
+        weight = table[qweight.long()].view(qweight.shape[0], num_groups, -1) * scale
+        weight = weight.view_as(qweight)
+    else:
+        weight = dequantize(qweight.view(qweight.shape[0], num_groups, -1), scale, zero).view_as(qweight)
     if perm is not None:
         invperm = perm.argsort()
         weight = weight[:, invperm]


### PR DESCRIPTION
## Summary
- extend quantization utilities with NVFP4 table and scale calculations
- allow selecting NVFP4 format via CLI for OLMoE models
- update packaging and metadata to record quantization format

## Testing
- `python -m py_compile src/quant_utils.py src/gptq_loop.py src/gptq.py quant.py pack_quantized_model.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a978178fc83328e6b5a5acfa4a2f8